### PR TITLE
Abbreviations: Add rendering of abbreviations in the MS docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.iml
 .idea
 /venv
+__pycache__
+.vscode

--- a/data/abbreviations.yml
+++ b/data/abbreviations.yml
@@ -1,0 +1,15 @@
+abbreviation:
+  RTA: Real Time Analyzer
+  SoF: Sends on Faders
+  EQ: Equalizer
+  GEQ: Graphic Equalizer
+  GR: Gain Reduction
+  DCA: Digitally Controlled Amplifier
+  MCA: Mix DCA
+  IDCA: Internal DCA
+  FX: Effects
+  API: Application Programming Interface
+  OSC: Open Sound Control
+  PEQ: Parametric Equalizer
+  REST: Representational State Transfer
+  

--- a/docs/feature-list.md
+++ b/docs/feature-list.md
@@ -42,16 +42,16 @@ This page lists all the special features in the professional version.
 | Feature                                            | Pro | Free | Model                                                        | Platform |
 |----------------------------------------------------|-----|------|--------------------------------------------------------------|----------|
 | Channel parameters                                 | X   | X    | Any                                                          | Any      |
-| FX access                                          | X   | X    | Any                                                          | Any      |
+| {{ abbr('FX') }} access | X | X | Any | Any |
 | FX Presets                                         | X   |      | Any                                                          | Any      |
 | Routing                                            | X   | X    | Any                                                          | Any      |
 | [Layers](layers.md)                                | X   | X    | Any                                                          | Any      |
 | [Fixed layer mix](layers.md)                       | X   |      | Any                                                          | Any      |
-| [Unlimited DCA](layer-idcas.md)                    | X   | X    | Any                                                          | Any      |
-| [MCAs](mca.md)                                     | X   | X    | Any                                                          | Any      |
+| [Unlimited {{ abbr('DCA') }}](layer-idcas.md) | X | X | Any | Any |
+| [{{ abbr('MCA') }}s](mca.md) | X | X | Any | Any |
 | [App-Link](app-link.md)                            | X   | X    | Any                                                          | Any      |
 | [Gain on fader](sends-on-faders.md#gain-on-faders) | X   |      | Any                                                          | Any      |
-| RTA                                                | X   | X    | Any\*                                                        | Any      |
+| {{ abbr('RTA') }} | X | X | Any\* | Any |
 | [Channel links](channel-links.md)                  | X   | X    | Any                                                          | Any      |
 | [Channel quick-gang](channel-links.md#quick-gang)  | X   | X    | Any                                                          | Any      |
 | Password protection                                | X   | X    | [XM32](xm32/bus-password.md)/[XAir](xair/bus-password.md)/Qu | Any      |

--- a/docs/integrations/apis.md
+++ b/docs/integrations/apis.md
@@ -1,12 +1,12 @@
 # APIs
-Mixing Station provides different APIs for integration with external software and hardware.
+Mixing Station provides different {{ abbr('API') }}s for integration with external software and hardware.
 The goal of these APIs is to cover the majority of console parameters with a unified API, allowing your application to work with every mixer supported by Mixing Station.
 
 ## Overview
 Note that the *full* set of APIs is only available in the desktop version of Mixing Station.
 
 ## Configure APIs
-To enable API access, open the [global app settings](../settings/global.md) and enable REST and/or OSC (Open Sound Control).
+To enable {{ abbr('API') }} access, open the [global app settings](../settings/global.md) and enable {{ abbr('REST') }} and/or {{ abbr('OSC') }}.
 
 ## Data Types
 The following data types are used:

--- a/docs/layer-idcas.md
+++ b/docs/layer-idcas.md
@@ -3,16 +3,15 @@ Mixing Station can created an unlimited number of DCAs, called "IDCA" channels.
 
 It is also possible to create an IDCA which changes the send level of multiple channels instead of the LR mix.
 
-
 ## New IDCA
-To add a new IDCA to a layer, open the `Layer Setup` view.
+To add a new {{ abbr('IDCA') }} to a layer, open the `Layer Setup` view.
 Press the `+` symbol in the menu and select `IDCA` to open the `IDCA Setup` view as shown below.
 
 ![New IDCA](gif/new-idca.gif)
 
 ## IDCA Setup
 This view allows you to assign channels to an IDCA.
-Select the mix you want the IDCA to control by pressing the button on the right side of 
+Select the mix you want the IDCA to control by pressing the button on the right side of
 the `Target Mix` label. By default `Main LR` is selected.
 Now you can select the channels you want the IDCA to control.
 

--- a/docs/settings/app.md
+++ b/docs/settings/app.md
@@ -39,10 +39,9 @@ These settings are related to the mixer and channel views.
 ### Global knobs / sliders
 This section configures how the knobs and sliders behave. The settings apply to all knobs in the app except sliders in a channel strip, which are configured in the `Channel Strip` tab.
 
-
-### DCA Spill
+### {{ abbr('DCA') }} Spill
 Enables a Midas Pro style popgroup functionality.
-When tapping on a channel button of a DCA/group, the assigned channels will be shown in the mixer instead of opening the DCA/group. To edit an DCA/IDCA while popgroup mode is enabled, **press and hold** the channel button.
+When tapping on a channel button of a DCA/IDCA group, the assigned channels will be shown in the mixer instead of opening the DCA/group. To edit an DCA/IDCA while popgroup mode is enabled, **press and hold** the channel button.
 
 When selecting an IDCA in popgroup mode, the displayed channels do **not** follow the currently selected sends on fader selection. Instead the assigned target mix of the IDCA is used.
 
@@ -63,13 +62,13 @@ Vocal
 ```
 If you open `Ch 5` and press `->`, will move to `Ch 11` instead of `Ch 6`.
 
-### FX Popup
+### {{ abbr('FX') }} Popup
 When enabled, shows tap delay buttons in the mutegroup popup.
 
-### SoF list
+### {{ abbr('SoF') }} list
 When enabled, shows a "sends on fader" list instead of the dropdown menu.
 
-### RTA Follow
+### {{ abbr('RTA') }} Follow
 When enabled, the app will always change the RTA source to the currently open channel.
 Depending on the mixer this means that the app will change the PAFL selection.
 
@@ -88,7 +87,7 @@ Defines how long the peak indicator should be shown before resetting.
 ### Decay
 Defines how fast the meter should decay (fall down).
 
-### GR level plot
+### {{ abbr('GR') }} level plot
 Enables a history plot of the dynamics input and gain reduction signal.
 ![timeline](../img/dyn-timeline.png)
 

--- a/docs/settings/channel-strip.md
+++ b/docs/settings/channel-strip.md
@@ -12,7 +12,7 @@ Drag directly on an item to resize it. Drag on the left side of an item to chang
 ## Fader
 This section configures the fader.
 
-- `Show groups`: When enabled, all assigned DCA and Mutegroups will be shown on the right of the fader.
+- `Show groups`: When enabled, all assigned {{ abbr('DCA') }} and Mutegroups will be shown on the right of the fader.
 - `Fader touch`: Defines what should happen if the fader is touched.
 - `Double tap`: Defines what should happen if the fader is double tapped.
 

--- a/docs/settings/global.md
+++ b/docs/settings/global.md
@@ -33,8 +33,7 @@ Autostart allows you to configure which mixer the app should connect to when sta
 This is useful for installation purposes where the app should always connect to a mixer without user interaction.
 
 ### API
-Only available on Desktop platform. Enables API access for Mixing Station. 
-
+Only available on Desktop platform. Enables {{ abbr('API') }} access for Mixing Station.
 
 ### Auto reconnect
 When enabled, the app automatically reconnects to the mixer in the case of a connection error.

--- a/docs/soundcraft/si-performer.md
+++ b/docs/soundcraft/si-performer.md
@@ -2,7 +2,7 @@
 
 The performer and expression series has certain limitations when it comes to remote controlling.
 Mixing Station currently implements all parameters which can be remote controlled. 
-Any other features such as Mutegroups, FX or routing **cannot be implemented**.
+Any other features such as Mutegroups, {{ abbr('FX') }} or routing **cannot be implemented**.
 
 The following parameters are **not controllable** via network due to firmware limitations:
 

--- a/docs/ui-controls.md
+++ b/docs/ui-controls.md
@@ -45,7 +45,7 @@ and the movements will be more precise.
 
 Additionally, you can tap the areas highlighted in red above to nudge the fader by 0.25db increments.
 
-- GEQ: **Double tap** to reset the value
+- {{ abbr('GEQ') }}: **Double tap** to reset the value
 
 ## Sliders
 
@@ -55,7 +55,7 @@ Default behaviour:
 - **Double tap** to reset the value to the default
 - **Drag** to change the value
 
-Sliders are used in some FX views and in the knob popup described above.
+Sliders are used in some {{ abbr('FX') }} views and in the knob popup described above.
 The white line indicates the default value for this parameter.
 
 ![Slider popup](img/slider-popup.png)

--- a/docs/wing/general.md
+++ b/docs/wing/general.md
@@ -2,7 +2,7 @@
 The mixer allows up to 16 simultaneous connections.
 
 # RTA
-As with most mixers there is only one RTA available.
+As with most mixers there is only one {{ abbr('RTA') }} available.
 
 In comparison to the XM32 series, the mixer will always override the RTA source if not locked.
 This means that the RTA shown in the app will be different from the actual selected channel.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,14 @@
+def define_env(env):
+    """
+    This is the hook for the functions (new form)
+    """
+
+    @env.macro
+    def abbr(abbreviation):
+        "Create an <abbr/>"
+        try:
+            title=env.variables.abbreviation[abbreviation]
+            return "<abbr title=\"{title}\">{abbreviation}</abbr>".format(title=title, abbreviation=abbreviation)
+        except:
+            return abbreviation
+    

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,9 @@ markdown_extensions:
 
 plugins:
   - search
+  - macros:
+      include_yaml:
+        - data/abbreviations.yml
   - mkdocs-video:
       is_video: True
       video_muted: True

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mkdocs_puml
 mkdocs-video==1.5.*
 mkdocs-redirects
 mkdocs-print-site-plugin
+mkdocs-macros


### PR DESCRIPTION
Include the ability to render abbreviations (as `<abbr/>` HTML elements) using the `mkdocs-macros` plugin with a simple Python macro.

Example:  to include an HTML abbreviations for "GEQ" and "RTA":

```md
To see if the smiley-face pattern for your {{ abbr('GEQ') }} faders is working, pull
up the {{ abbr('RTA') }} and look at the post-EQ rendering...
```

Would result in:

```html
To see if the smiley-face pattern for your <abbr title="Graphic Equalizer">GEQ</abbr> faders is working, pull
up the <abbr title="Real Time Analyzer">RTA</abbr> and look at the post-EQ rendering...
```


![image](https://github.com/davidgiga1993/mixing-station-docs/assets/577439/efd5bbae-4c69-4053-8ea6-d77d5e668227)
