### PR TITLE
[#16] MCA page missing from TOC

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
   - Advanced:
       - App-Link: app-link.md
       - IDCAs: layer-idcas.md
+      - MCAs: mca.md
       - Channel Links: channel-links.md
       - Mix copy: mix-copy.md
       - Mix presets: mix-presets.md


### PR DESCRIPTION
Add the MCA documentation page to the Table of Contents under the "Advanced" section.

Fixes #16