### PR TITLE
Clarify MCAs with restricted mode

### DIFF
--- a/docs/layer-idcas.md
+++ b/docs/layer-idcas.md
@@ -2,7 +2,7 @@
 
 Mixing Station can created an unlimited number of DCAs, called "IDCA" channels.
 
-It is also possible to create an IDCA which changes the send level of multiple channels instead of the LR mix.
+It is also possible to create an IDCA which changes the send level of multiple channels instead of the LR mix. Unlike MCAs, IDCAs also work in restricted mode, when the user access is limited to certain mix(es).
 
 ## New IDCA
 

--- a/docs/mca.md
+++ b/docs/mca.md
@@ -21,3 +21,5 @@ can change the level of all assigned channels relatively.
 
 Every time you enter this mode, the fader will be reset to the
 center, so you have the entire range to motion.
+
+Note: MCAs only work in in unrestricted mode. Please use [IDCAs](layer-idcas.md) if you want to give your performers the ability to control volume groups for their mix on stage.


### PR DESCRIPTION
Hi @davidgiga1993, could you please confirm that this behaviour is always the case? I played around with this for this week with Mixing Station and an SQ desk, and this looks correct.
I think this could be a useful addition, since I firstly assumed that MCAs would also work for a fixed monitor mix in restricted mode.

Cheers.