### PR TITLE
docs: fix typo and clarify fine mode description

### DIFF
--- a/docs/ui-controls.md
+++ b/docs/ui-controls.md
@@ -85,7 +85,8 @@ Contains two **scrollable** bars for layers and access to [sends on faders](send
 
 ### Fine mode
 
-When enabled faders will be more less sensitive and you can make smaller adjustments.
+When enabled, faders will be less sensitive, allowing for smaller and more precise adjustments.
+
 
 ### Mute enable
 


### PR DESCRIPTION
This PR corrects a typo in the documentation and updates the description of "fine mode" to clarify that faders become less sensitive, enabling smaller and more precise adjustments.